### PR TITLE
Add uname syscall and uname command

### DIFF
--- a/usr/include/sys/Makefile
+++ b/usr/include/sys/Makefile
@@ -16,7 +16,7 @@ HFILES = acct.h \
          tty.h \
          types.h \
          user.h \
-	 utsname.h \
+	 utsname.h
 
 all: $(HFILES)
 

--- a/usr/include/sys/Makefile
+++ b/usr/include/sys/Makefile
@@ -15,7 +15,8 @@ HFILES = acct.h \
          timeb.h \
          tty.h \
          types.h \
-         user.h
+         user.h \
+	 utsname.h \
 
 all: $(HFILES)
 

--- a/usr/include/sys/utsname.h
+++ b/usr/include/sys/utsname.h
@@ -1,0 +1,15 @@
+/* @(#)utsname.h	1.1 */
+
+#ifndef __V7_SYS_UTSNAME_H
+#define __V7_SYS_UTSNAME_H
+
+struct utsname {
+	char	sysname[9];
+	char	nodename[9];
+	char	release[9];
+	char	version[9];
+	char	machine[9];
+};
+extern struct utsname utsname;
+
+#endif /* __V7_SYS_UTSNAME_H */

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -146,6 +146,7 @@ TARGETS = ac \
           tsort \
           tty \
           umount \
+	  uname \
           uniq \
           units \
           update \

--- a/usr/src/cmd/uname.c
+++ b/usr/src/cmd/uname.c
@@ -1,0 +1,66 @@
+/* uname - print operating system information */
+/* Taken from the System V sources here: https://github.com/calmsacibis995/sysv-src */
+
+/*	@(#)uname.c	1.2	*/
+#include	<stdio.h>
+#include	<sys/utsname.h>
+
+struct utsname	unstr, *un;
+
+int main(int argc, char **argv)
+{
+	register i;
+	int	sflg=1, nflg=0, rflg=0, vflg=0, mflg=0, errflg=0;
+	int	optlet;
+
+	un = &unstr;
+	uname(un);
+
+	while((optlet=getopt(argc, argv, "asnrvm")) != EOF) switch(optlet) {
+	case 'a':
+		sflg++; nflg++; rflg++; vflg++; mflg++;
+		break;
+	case 's':
+		sflg++;
+		break;
+	case 'n':
+		nflg++;
+		break;
+	case 'r':
+		rflg++;
+		break;
+	case 'v':
+		vflg++;
+		break;
+	case 'm':
+		mflg++;
+		break;
+	case '?':
+		errflg++;
+	}
+	if(errflg) {
+		fprintf(stderr, "usage: uname [-snrvma]\n");
+		exit(1);
+	}
+	if(nflg | rflg | vflg | mflg) sflg--;
+	if(sflg)
+		fprintf(stdout, "%.9s", un->sysname);
+	if(nflg) {
+		if(sflg) putchar(' ');
+		fprintf(stdout, "%.9s", un->nodename);
+	}
+	if(rflg) {
+		if(sflg | nflg) putchar(' ');
+		fprintf(stdout, "%.9s", un->release);
+	}
+	if(vflg) {
+		if(sflg | nflg | rflg) putchar(' ');
+		fprintf(stdout, "%.9s", un->version);
+	}
+	if(mflg) {
+		if(sflg | nflg | rflg | vflg) putchar(' ');
+		fprintf(stdout, "%.9s", un->machine);
+	}
+	putchar('\n');
+	exit(0);
+}

--- a/usr/src/libc/Makefile
+++ b/usr/src/libc/Makefile
@@ -47,6 +47,7 @@ GEN_OBJECTS   = cuexit.o \
                 execvp.o \
                 getenv.o \
                 getlogin.o \
+		getopt.o \
                 perror.o \
                 sleep.o \
                 timezone.o \
@@ -79,6 +80,7 @@ GEN_OBJECTS   = cuexit.o \
                 rindex.o \
                 strcat.o \
                 strncat.o \
+		strchr.o \
                 strcmp.o \
                 strncmp.o \
                 strcpy.o \
@@ -133,6 +135,7 @@ SYS_OBJECTS   = access.o \
                 times.o \
                 umask.o \
                 umount.o \
+		uname.o \
                 unlink.o \
                 utime.o \
                 wait.o \

--- a/usr/src/libc/gen/getopt.c
+++ b/usr/src/libc/gen/getopt.c
@@ -1,0 +1,75 @@
+/* Taken from the Ultrix-11 sources, here: https://github.com/calmsacibis995/ultrix11-src/blob/main/src/libc/sysV/getopt.c */
+
+/**********************************************************************
+ *   Copyright (c) Digital Equipment Corporation 1984, 1985, 1986.    *
+ *   All Rights Reserved. 					      *
+ *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
+ **********************************************************************/
+
+/*	SCCSID: @(#)getopt.c	3.0	4/22/86	*/
+/*	(System 5)	1.5	*/
+/*	3.0 SID #	1.2	*/
+/*LINTLIBRARY*/
+#define NULL	0
+#define EOF	(-1)
+#define ERR(s, c)	if(opterr){\
+	extern int strlen(), write();\
+	char errbuf[2];\
+	errbuf[0] = c; errbuf[1] = '\n';\
+	(void) write(2, argv[0], (unsigned)strlen(argv[0]));\
+	(void) write(2, s, (unsigned)strlen(s));\
+	(void) write(2, errbuf, 2);}
+
+extern int strcmp();
+extern char *strchr();
+
+int	opterr = 1;
+int	optind = 1;
+int	optopt;
+char	*optarg;
+
+int
+getopt(argc, argv, opts)
+int	argc;
+char	**argv, *opts;
+{
+	static int sp = 1;
+	register int c;
+	register char *cp;
+
+	if(sp == 1)
+		if(optind >= argc ||
+		   argv[optind][0] != '-' || argv[optind][1] == '\0')
+			return(EOF);
+		else if(strcmp(argv[optind], "--") == NULL) {
+			optind++;
+			return(EOF);
+		}
+	optopt = c = argv[optind][sp];
+	if(c == ':' || (cp=strchr(opts, c)) == NULL) {
+		ERR(": illegal option -- ", c);
+		if(argv[optind][++sp] == '\0') {
+			optind++;
+			sp = 1;
+		}
+		return('?');
+	}
+	if(*++cp == ':') {
+		if(argv[optind][sp+1] != '\0')
+			optarg = &argv[optind++][sp+1];
+		else if(++optind >= argc) {
+			ERR(": option requires an argument -- ", c);
+			sp = 1;
+			return('?');
+		} else
+			optarg = argv[optind++];
+		sp = 1;
+	} else {
+		if(argv[optind][++sp] == '\0') {
+			sp = 1;
+			optind++;
+		}
+		optarg = NULL;
+	}
+	return(c);
+}

--- a/usr/src/libc/gen/strchr.c
+++ b/usr/src/libc/gen/strchr.c
@@ -1,0 +1,28 @@
+/* Taken from the Ultrix-11 sources, here: https://github.com/calmsacibis995/ultrix11-src/blob/main/src/libc/sysV/strchr.c */
+/**********************************************************************
+ *   Copyright (c) Digital Equipment Corporation 1984, 1985, 1986.    *
+ *   All Rights Reserved. 					      *
+ *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
+ **********************************************************************/
+
+/*	SCCSID: @(#)strchr.c	3.0	4/22/86	*/
+/*	(System 5)	1.2	*/
+/*	3.0 SID #	1.2	*/
+/*LINTLIBRARY*/
+/*
+ * Return the ptr in sp at which the character c appears;
+ * NULL if not found
+ */
+
+#define	NULL	0
+
+char *
+strchr(sp, c)
+register char *sp, c;
+{
+	do {
+		if(*sp == c)
+			return(sp);
+	} while(*sp++);
+	return(NULL);
+}

--- a/usr/src/libc/sys/armv6k/uname.s
+++ b/usr/src/libc/sys/armv6k/uname.s
@@ -1,0 +1,25 @@
+@ C library -- uname
+@ uname(unixname);
+@ unixname[0], ...unixname[7] contain the unixname
+
+.syntax unified
+.arm
+.section text
+
+.global uname
+.extern errno
+
+.type uname,%function
+uname:
+	push {fp, lr}					@ setup the stack
+	add fp, sp, #0					@ adjust the frame pointer
+	push {r0}						@ fname
+	mov lr, sp						@ pointer to indirect arguments stored in lr
+	swi #57							@ uname syscall number
+	bcc 1f							@ syscalls return carry-clear for success and carry-set for error
+	ldr r2, =errno                  @ load up the address of errno
+    str r0, [r2]                    @ stash the returned errno in the error case
+    mov r0, #-1                     @ syscalls return -1 for error
+1:  sub sp, fp, #0                  @ restore our stack pointer to point to our stack frame
+    pop {fp, pc}                    @ restore caller frame and return
+.size uname, . - uname

--- a/usr/sys/h/utsname.h
+++ b/usr/sys/h/utsname.h
@@ -1,0 +1,13 @@
+/* @(#)utsname.h	1.1 */
+
+#ifndef __V7_SYS_UTSNAME_H
+#define __V7_SYS_UTSNAME_H
+
+struct utsname {
+	char	sysname[9];
+	char	nodename[9];
+	char	release[9];
+	char	version[9];
+	char	machine[9];
+};
+extern struct utsname utsname;


### PR DESCRIPTION
I have implemented a new sycall, the uname syscall. It allows V7 to display operating system information by running the command 'uname -a' (which is also implemented). These are taken from the Ultrix-11 and System V sources.